### PR TITLE
Upgrade composer requirements to the latest doctrine/collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### `v0.5.1` (2014-03-05)
+
+* Upgrade composer requirements to the latest doctrine/collections
+
 ### `v0.5.0` (2014-03-04)
 
 * Phlack now contains a (partial) implementation of the [Slack API](https://api.slack.com)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.4",
         "guzzle/guzzle": "~3.8",
-        "doctrine/collections": "1.1.*",
+        "doctrine/collections": "~1",
         "symfony/options-resolver": "~2.4"
     },
     "suggest": {


### PR DESCRIPTION
I was trying to install rocketeer-slack (a php plugin notifying slack channel whenever somebody deploys an app using Rocketeer) and got stuck into broken dependencies.

My latest laravel pack is using latest doctrine/collections, so I had to fork your package and bump the composer requirements.

Since all tests on travis-ci are passing correctly, could you accept my changes? So that I could create another pull request for aforementioned plugin. :)

Btw, new tag is also needed.

(Reopening PR on develop branch)
