### PR TITLE
Allow sending direct message to user

### DIFF
--- a/src/Crummy/Phlack/Message/Message.php
+++ b/src/Crummy/Phlack/Message/Message.php
@@ -41,7 +41,7 @@ class Message extends Partial implements MessageInterface
 
         $resolver->setNormalizers([
             'channel' => function (Options $options, $value) {
-                return empty($value) ? $value : (0 === strpos($value, '#') ? $value : '#' . $value);
+                return empty($value) ? $value : (0 === strpos($value, '#') ? $value : (0 === strpos($value, '@') ? $value : '#' . $value));
             },
             'icon_emoji' => function(Options $options, $value) {
                 return empty($value) ? $value : sprintf(':%s:', trim($value, ':'));
@@ -66,7 +66,7 @@ class Message extends Partial implements MessageInterface
     public function setChannel($channel)
     {
         if (!empty($channel)) {
-            $this->data['channel'] = (0 === strpos($channel, '#') ? $channel : '#' . $channel);
+            $this->data['channel'] = (0 === strpos($channel, '#') ? $channel : (0 === strpos($channel, '@') ? $channel : '#' . $channel));
         }
         return $this;
     }


### PR DESCRIPTION
Opening new PR after squashing commits and closing PR on master branch.

Original PR text: 
>I wanted to send a direct message to user, and if I specify channel as @slackusername, your method setDefaultOptions was adding # sign to beginning of my channel name, so final channel would look like #@slackusername. 

>I added one more check if channel starts with @ to avoid adding #, so we can send direct messages to user.