### PR TITLE
Add support for custom WebHook URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,54 +7,62 @@ Phlack eases the creation of [Slack Integrations](http://slack.com) in PHP.
 
 **Update:** Phlack now contains a partial implementation of the [Slack API](http://api.slack.com). For details, see the [API Docs](#slack-api) section below.
 
-## Installation & Configuration
+## Installation
 
-### Installation
-via Composer
+via [composer](https://packagist.org/packages/mcrumm/phlack):
 
-```json
-{
-    "require": {
-        "mcrumm/phlack": "dev-master"
-    }
-}
+```
+composer require mcrumm/phlack
 ```
 
-### Configuration
+## Basic Usage
 
-Create a hash containing your slack `username` and integrations `token`.
-
-*Your `username` is the unique portion of your [Slack](http://slack.com) subdomain.  For example, if your subdomain was `groundctrl.slack.com`, your username will be `groundctrl`.*
-
+### Send a Message
 
 ```php
 <?php
-$config = [ 'username' => 'my_slack_user', 'token' => 'my_slack_token' ]);
+$phlack = new Crummy\Phlack\Phlack('https://my.webhook.url');
+$message = new Crummy\Phlack\Message\Message('Hello, from Phlack!');
+
+$phlack->send($message);
 ```
 
-## Usage
+## Advanced Usage
 
-### Getting Phlack
+### Configuration Options
 
-Get a [Phlack](src/Crummy/Phlack/Phlack.php) object by instantiating it with a [PhlackClient](src/Crummy/Phlack/Bridge/Guzzle/PhlackClient.php) or using its static `factory()` method.
+#### Legacy WebHook URLs
+
+A previous version of Incoming Webhooks used a generic webhook path for every team URL. If your webhook URL starts with something like `myteam.slack.com`, give Phlack your team name and Incoming Webhook token, and it will do the rest:
+
+```php
+<?php
+$phlack  = new Crummy\Phlack\Phlack([
+    'username' => 'myteam',
+    'token'    => 'my_webhook_token'
+]);
+```
 
 #### via `factory()`:
+
+If you prefer, you can instantiate Phlack via its static `factory()` method:
+
 ```php
 <?php
-//...
-use Crummy\Phlack\Phlack;
-$phlack = Phlack::factory($config);
+$phlack = Crummy\Phlack\Phlack::factory($config);
 ```
 
 #### via `new Phlack()`:
+
+Besides a webhook url or an array configuration, Phlack will also accept a `PhlackClient` instance as a constructor argument:
+
 ```php
 <?php
-use Crummy\Phlack\Bridge\Guzzle\PhlackClient;
-use Crummy\Phlack\Phlack;
-
-$client = PhlackClient::factory($config);
-$phlack = new Phlack($client);
+$client = new Crummy\Phlack\Bridge\Guzzle\PhlackClient('https://my.webhook.url');
+$phlack = new Crummy\Phlack\Phlack($client);
 ```
+
+>**Note:** The constructor and factory method both accept the same types of arguments: a string representing the webhook url, an array of client config options, or a `PhlackClient` object.
 
 #### :heart: for Guzzle
 The PhlackClient is simply a web service client implemented with [Guzzle](http://guzzlephp.org).  Examine its [service description](src/Crummy/Phlack/Bridge/Guzzle/Resources/slack.json) for more details.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/console": "~2.4",
         "symfony/http-foundation": "~2.4",
         "behat/behat": "2.5.*",
-        "phpspec/phpspec": "~2.1@dev",
+        "phpspec/phpspec": "~2.3@dev",
         "phpspec/nyan-formatters": "1.*",
         "henrikbjorn/phpspec-code-coverage": "~0.2"
     },

--- a/examples/config.json.dist
+++ b/examples/config.json.dist
@@ -3,8 +3,7 @@
         "phlack": {
             "class": "Crummy\\Phlack\\Bridge\\Guzzle\\PhlackClient",
             "params": {
-                "username": "",
-                "token": ""
+                "url": ""
             }
         },
         "phlack_api": {

--- a/spec/Crummy/Phlack/Bridge/Guzzle/LegacyUrlPluginSpec.php
+++ b/spec/Crummy/Phlack/Bridge/Guzzle/LegacyUrlPluginSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\Crummy\Phlack\Bridge\Guzzle;
 
-use Crummy\Phlack\Bridge\Guzzle\PhlackPlugin;
+use Crummy\Phlack\Bridge\Guzzle\LegacyUrlPlugin;
 use Guzzle\Common\Event;
 use Guzzle\Http\Message\Request;
 use Guzzle\Http\QueryString;
@@ -10,7 +10,7 @@ use Guzzle\Http\Url;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-class PhlackPluginSpec extends ObjectBehavior
+class LegacyUrlPluginSpec extends ObjectBehavior
 {
     function let()
     {
@@ -19,7 +19,7 @@ class PhlackPluginSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Crummy\Phlack\Bridge\Guzzle\PhlackPlugin');
+        $this->shouldHaveType('Crummy\Phlack\Bridge\Guzzle\LegacyUrlPlugin');
     }
 
     function it_is_an_event_subscriber()
@@ -36,23 +36,12 @@ class PhlackPluginSpec extends ObjectBehavior
     {
         $e->offsetGet('request')->willReturn($request);
         $request->getUrl(true)->willReturn($url);
-        $url->setHost(sprintf(PhlackPlugin::BASE_URL, 'username'))->willReturn($url);
+        $url->setHost(sprintf(LegacyUrlPlugin::BASE_URL, 'username'))->willReturn($url);
+        $url->setPath(LegacyUrlPlugin::WEBHOOK_PATH)->willReturn($url);
         $url->setScheme('https')->willReturn($url);
         $request->setUrl($url)->shouldBeCalled()->willReturn($request);
         $request->getQuery()->shouldBeCalled()->willReturn($q);
 
         $this->onRequestBeforeSend($e)->shouldReturn(null);
-    }
-
-    public function getMatchers()
-    {
-        return [
-            'haveKey' => function($subject, $key) {
-                return array_key_exists($key, $subject);
-            },
-            'haveValue' => function($subject, $value) {
-                return in_array($value, $subject);
-            },
-        ];
     }
 }

--- a/spec/Crummy/Phlack/Bridge/Guzzle/PhlackClientSpec.php
+++ b/spec/Crummy/Phlack/Bridge/Guzzle/PhlackClientSpec.php
@@ -2,12 +2,14 @@
 
 namespace spec\Crummy\Phlack\Bridge\Guzzle;
 
-use Guzzle\Service\Client;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class PhlackClientSpec extends ObjectBehavior
 {
+    static $mockUrl    = 'https://hooks.slack.com/services/AAAA/BBBB/CCCC';
+    static $mockConfig = [ 'username' => 'foo', 'token' => 'bar' ];
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Crummy\Phlack\Bridge\Guzzle\PhlackClient');
@@ -18,18 +20,52 @@ class PhlackClientSpec extends ObjectBehavior
         $this->shouldHaveType('\Guzzle\Service\Client');
     }
 
-    function its_factory_requires_a_config()
+    function its_factory_accepts_a_custom_base_url()
     {
-        $this::factory([ 'username' => 'foo', 'token' => 'bar' ])->shouldReturnAnInstanceOf($this);
+        $this->beConstructedThrough('factory', [
+            [ 'url' => self::$mockUrl ]
+        ]);
+
+        $this->getBaseUrl()->shouldBe(self::$mockUrl);
+    }
+
+    function it_accepts_a_config_hash_through_factory()
+    {
+        $this->beConstructedThrough('factory', [ self::$mockConfig ]);
+
+        $this->getDescription()->shouldBeAnInstanceOf('Guzzle\Service\Description\ServiceDescription');
+    }
+
+    function its_factory_accepts_a_single_argument_for_url()
+    {
+        $this->beConstructedThrough('factory', [ self::$mockUrl ]);
+
+        $this->getBaseUrl()->shouldBe(self::$mockUrl);
     }
 
     function its_factory_requires_a_username()
     {
-        $this->shouldThrow()->during('factory', array('foo' => 'user', 'token' => 'abc123'));
+        $this->beConstructedThrough('factory', [
+            [ 'foo' => 'user', 'token' => 'abc123' ]
+        ]);
+
+        $this->shouldThrow()->duringInstantiation();
     }
 
     function its_factory_requires_a_token()
     {
-        $this->shouldThrow()->during('factory', array('username' => 'bar'));
+        $this->beConstructedThrough('factory', [
+            [ 'username' => 'mr.no_token' ]
+        ]);
+
+        $this->shouldThrow()->duringInstantiation();
+    }
+
+    function it_attaches_a_listener_in_legacy_mode()
+    {
+        $this->beConstructedThrough('factory', [ self::$mockConfig ]);
+
+        // Redirect plugin + LegacyUrlPlugin = 2 request.before_send plugins.
+        $this->getEventDispatcher()->getListeners('request.before_send')->shouldHaveCount(2);
     }
 }

--- a/src/Crummy/Phlack/Bridge/Guzzle/LegacyUrlPlugin.php
+++ b/src/Crummy/Phlack/Bridge/Guzzle/LegacyUrlPlugin.php
@@ -6,9 +6,10 @@ use Guzzle\Common\Event;
 use Guzzle\Http\Message\RequestInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PhlackPlugin implements EventSubscriberInterface
+class LegacyUrlPlugin implements EventSubscriberInterface
 {
     const BASE_URL = '%s.slack.com';
+    const WEBHOOK_PATH = '/services/hooks/incoming-webhook';
 
     private $username;
     private $token;
@@ -43,7 +44,8 @@ class PhlackPlugin implements EventSubscriberInterface
 
         $url = $request->getUrl(true)
             ->setScheme('https')
-            ->setHost(sprintf(self::BASE_URL, $this->username));
+            ->setHost(sprintf(self::BASE_URL, $this->username))
+            ->setPath(self::WEBHOOK_PATH);
 
         $request->setUrl($url)
             ->getQuery()

--- a/src/Crummy/Phlack/Bridge/Guzzle/PhlackClient.php
+++ b/src/Crummy/Phlack/Bridge/Guzzle/PhlackClient.php
@@ -8,22 +8,58 @@ use Guzzle\Service\Description\ServiceDescription;
 
 class PhlackClient extends Client
 {
+    /** @var array */
+    protected $defaultConfig = [
+        'request.options' => [
+            'exceptions'  => false,
+        ],
+    ];
+
+    /** @var array */
+    protected $legacyRequirements = [ 'username', 'token' ];
+
+    /**
+     * @param string     $baseUrl
+     * @param array|null $config
+     */
+    public function __construct($baseUrl = LegacyUrlPlugin::BASE_URL, $config = null)
+    {
+        $legacyMode = $this->isLegacyUrl($baseUrl);
+
+        $config = Collection::fromConfig(
+            $config ?: [ ],
+            $this->defaultConfig,
+            $legacyMode ? $this->legacyRequirements : [ ]
+        );
+
+        if ($legacyMode) {
+            $this->addSubscriber(new LegacyUrlPlugin($config['username'], $config['token']));
+            unset($config['username'], $config['token']);
+        }
+
+        parent::__construct($baseUrl, $config);
+
+        $this->setDescription(ServiceDescription::factory(__DIR__.'/Resources/slack.json'));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public static function factory($config = array())
     {
-        $default  = [
-            'base_url'        => PhlackPlugin::BASE_URL,
-            'request.options' => [
-                'exceptions'  => false,
-            ],
-        ];
-        $required = [ 'username', 'token' ];
+        if (! is_array($config)) {
+            return new self($config);
+        }
 
-        $config = Collection::fromConfig($config, $default, $required);
-        $client = new self($config['base_url'], $config);
+        return new self(isset($config['url']) ? $config['url'] : null, $config);
+    }
 
-        $client->addSubscriber(new PhlackPlugin($config['username'], $config['token']));
-        $client->setDescription(ServiceDescription::factory(__DIR__.'/Resources/slack.json'));
-
-        return $client;
+    /**
+     * @param string $baseUrl
+     * @return bool
+     */
+    private function isLegacyUrl($baseUrl)
+    {
+        return (null === $baseUrl || $baseUrl === LegacyUrlPlugin::BASE_URL);
     }
 }

--- a/src/Crummy/Phlack/Bridge/Guzzle/Resources/slack.json
+++ b/src/Crummy/Phlack/Bridge/Guzzle/Resources/slack.json
@@ -5,7 +5,6 @@
     "operations": {
         "Send": {
             "httpMethod": "POST",
-            "uri": "/services/hooks/incoming-webhook",
             "summary": "POST Incoming WebHook",
             "responseClass":"\\Crummy\\Phlack\\Bridge\\Guzzle\\Response\\MessageResponse",
             "parameters": {

--- a/src/Crummy/Phlack/Common/Exception/UnexpectedTypeException.php
+++ b/src/Crummy/Phlack/Common/Exception/UnexpectedTypeException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Crummy\Phlack\Common\Exception;
+
+class UnexpectedTypeException extends \InvalidArgumentException
+{
+    /**
+     * @param mixed        $value
+     * @param string|array $expectedType
+     */
+    public function __construct($value, $expectedType)
+    {
+        parent::__construct(sprintf(
+            'Expected argument of type %s, %s given.',
+            is_array($expectedType) ? '(' . implode(' | ', $expectedType) . ')' : $expectedType,
+            is_object($value) ? get_class($value) : gettype($value)
+        ));
+    }
+}

--- a/src/Crummy/Phlack/Phlack.php
+++ b/src/Crummy/Phlack/Phlack.php
@@ -4,16 +4,26 @@ namespace Crummy\Phlack;
 
 use Crummy\Phlack\Bridge\Guzzle\PhlackClient;
 use Crummy\Phlack\Bridge\Guzzle\Response\MessageResponse;
+use Crummy\Phlack\Common\Exception\UnexpectedTypeException;
 use Crummy\Phlack\Message\MessageInterface;
 use Guzzle\Common\Collection;
 
 class Phlack extends Collection
 {
     /**
-     * @param PhlackClient $client
+     * Phlack Constructor.
+     *
+     * @param mixed $client
+     * @throws UnexpectedTypeException
      */
-    public function __construct(PhlackClient $client)
+    public function __construct($client)
     {
+        if (is_string($client) || is_array($client)) {
+            $client = new PhlackClient($client);
+        } elseif (! $client instanceof PhlackClient) {
+            throw new UnexpectedTypeException($client, ['string', 'array', 'Crummy\Phlack\Bridge\Guzzle\PhlackClient']);
+        }
+
         parent::__construct([
             'client'   => $client,
             'builders' => [],
@@ -24,20 +34,22 @@ class Phlack extends Collection
     }
 
     /**
-     * @param array $config
+     * Phlack Factory.
+     *
+     * @param array|string $config
      * @return Phlack
      */
-    static public function factory(array $config = [ ])
+    static public function factory($config = [ ])
     {
-        return new self(PhlackClient::factory($config));
+        return new self(new PhlackClient($config));
     }
 
     /**
-     * {@inhertiDoc}
+     * @return Phlack
      */
     public static function fromConfig(array $config = array(), array $defaults = array(), array $required = array())
     {
-        return new self($config['client']);
+        return new self(new PhlackClient($config));
     }
 
     /**


### PR DESCRIPTION
Provides a proper fix for #11.

**Changes:**

- `Phlack` and `PhlackClient` now support polymorphic values for `__construct()` and `::factory()`.  They can be given a WebHook URL or an array of config options.
- Renamed `PhlackPlugin` to `LegacyUrlPlugin` for clarity.
