### PR TITLE
Simplify message sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ composer require mcrumm/phlack
 ```php
 <?php
 $phlack = new Crummy\Phlack\Phlack('https://my.webhook.url');
-$message = new Crummy\Phlack\Message\Message('Hello, from Phlack!');
 
-$phlack->send($message);
+$response = $phlack->send('Hello, from Phlack!');
+
+if (200 === $response['status']) {
+    echo 'Success!';
+}
 ```
 
 ## Advanced Usage
@@ -112,6 +115,23 @@ if (200 != $response['status']) {
 
 echo 'The message was sent: ' . $message;
 ```
+
+### Custom Message Parameters
+
+Custom messages can be sent by using an array of [valid parameters](https://api.slack.com/incoming-webhooks):
+
+```php
+<?php
+$phlack->send([
+    'channel'      => '#random',
+    'icon_emoji'   => ':taco:',
+    'username'     => 'Phlack',
+    'unfurl_links' => true,
+    'text'         => 'I :heart: the <http://api.slack.com|Slack API>!',
+]);
+```
+
+> Note: No input validation is performed on custom message parameters. You are responsible for formatting channels, emojis, and text data yourself.
 
 #### Response
 

--- a/examples/custom.php
+++ b/examples/custom.php
@@ -1,0 +1,15 @@
+<?php
+
+$client  = require __DIR__ . '/client.php';
+$phlack  = new \Crummy\Phlack\Phlack($client);
+
+$response = $phlack->send([
+    'channel'      => '#random',
+    'icon_emoji'   => ':taco:',
+    'username'     => 'Phlack',
+    'unfurl_links' => true,
+    'text'         => 'I :heart: the <http://api.slack.com|Slack API>!',
+]);
+
+echo 'Response:' . PHP_EOL;
+var_dump($response);

--- a/examples/simple.php
+++ b/examples/simple.php
@@ -2,8 +2,8 @@
 
 $client  = require __DIR__ . '/client.php';
 $phlack  = new \Crummy\Phlack\Phlack($client);
-$message = new \Crummy\Phlack\Message\Message('Hello, from phlack!');
 
-echo 'Message Payload:' . PHP_EOL . $message . PHP_EOL;
-echo 'Result:' . PHP_EOL;
-var_dump($phlack->send($message));
+$response = $phlack->send('Hello, from Phlack!');
+
+echo 'Response:' . PHP_EOL;
+var_dump($response);


### PR DESCRIPTION
`Phlack::send()` now supports simple messages in the form of a `string`, custom message parameters via an `array`, or any `\JsonSerializable` object that returns an array from `jsonSerialize()`, such as a Phlack Message object.