### PR TITLE
Remove channel autoprefix

### DIFF
--- a/features/message.feature
+++ b/features/message.feature
@@ -33,7 +33,7 @@ Feature: Phlack Message
     Then I get the output:
       | output                                 |
       | {"text":"Default"}                     |
-      | {"text":"Dev","channel":"#dev"}        |
+      | {"text":"Dev","channel":"dev"}        |
       | {"text":"Ops","channel":"#ops"}        |
       | {"text":"Banana","channel":"##banana"} |
 
@@ -92,10 +92,11 @@ Feature: Phlack Message
       | 001  |         |          | package     |
       | 010  |         | albert   |             |
       | 011  |         | bob      | clock       |
-      | 100  | nbc     |          |             |
-      | 101  | cbs     |          | hourglass   |
-      | 110  | abc     | carl     |             |
-      | 111  | fox     | doge     | copyright   |
+      | 100  | #nbc     |          |             |
+      | 101  | #cbs     |          | hourglass   |
+      | 110  | #abc     | carl     |             |
+      | 111  | #fox     | doge     | copyright   |
+      | 112  | id       | test     |             |
     When I echo the message
     Then I get the output:
       | output                                                                       |
@@ -107,6 +108,7 @@ Feature: Phlack Message
       | {"text":"101","channel":"#cbs","icon_emoji":":hourglass:"}                   |
       | {"text":"110","channel":"#abc","username":"carl"}                            |
       | {"text":"111","channel":"#fox","username":"doge","icon_emoji":":copyright:"} |
+      | {"text":"112","channel":"id","username":"test"} |
 
   Scenario: Message Attachments
     Given these messages:

--- a/features/message_builder.feature
+++ b/features/message_builder.feature
@@ -15,10 +15,10 @@ Feature: Message Builder
     When I build the messages:
       | message            | channel |
       | A default message. |         |
-      | Message for bars.  | bar     |
+      | Message for bars.  | #bar    |
       | Message for foos.  | foo     |
     Then I should get the payload:
       | payload                                       |
       | {"text":"A default message."}                 |
       | {"text":"Message for bars.","channel":"#bar"} |
-      | {"text":"Message for foos.","channel":"#foo"} |
+      | {"text":"Message for foos.","channel":"foo"} |

--- a/spec/Crummy/Phlack/Message/MessageSpec.php
+++ b/spec/Crummy/Phlack/Message/MessageSpec.php
@@ -37,16 +37,14 @@ class MessageSpec extends ObjectBehavior
         $this->setChannel(self::CHANNEL)->shouldReturn($this);
     }
 
-    function it_ensures_channel_begins_with_a_hash()
-    {
-        $withHash = '#'.self::CHANNEL;
-        $this->setChannel(self::CHANNEL)->getChannel()->shouldReturn($withHash);
-        $this->setChannel($withHash)->getChannel()->shouldReturn($withHash);
-    }
-
     function it_allows_for_direct_messages_in_channel()
     {
         $this->setChannel('@mcrumm')->getChannel()->shouldReturn('@mcrumm');
+    }
+
+    function it_does_not_alter_passed_channel()
+    {
+        $this->setChannel(':channel_id')->getChannel()->shouldReturn(':channel_id');
     }
 
     function it_fluently_accepts_an_icon_emoji()
@@ -82,7 +80,7 @@ class MessageSpec extends ObjectBehavior
             ->__toString()
             ->shouldReturn(json_encode([
                 'text'        => self::TEXT,
-                'channel'     => '#'.self::CHANNEL
+                'channel'     => self::CHANNEL
             ]))
         ;
     }

--- a/src/Crummy/Phlack/Message/Message.php
+++ b/src/Crummy/Phlack/Message/Message.php
@@ -40,9 +40,6 @@ class Message extends Partial implements MessageInterface
         ]);
 
         $resolver->setNormalizers([
-            'channel' => function (Options $options, $value) {
-                return empty($value) ? $value : (0 === strpos($value, '#') ? $value : (0 === strpos($value, '@') ? $value : '#' . $value));
-            },
             'icon_emoji' => function(Options $options, $value) {
                 return empty($value) ? $value : sprintf(':%s:', trim($value, ':'));
             }
@@ -66,7 +63,7 @@ class Message extends Partial implements MessageInterface
     public function setChannel($channel)
     {
         if (!empty($channel)) {
-            $this->data['channel'] = (0 === strpos($channel, '#') ? $channel : (0 === strpos($channel, '@') ? $channel : '#' . $channel));
+            $this->data['channel'] = $channel;
         }
         return $this;
     }


### PR DESCRIPTION
1. Removed channel normalizer from Message.php, this normalizer automatically prefixed channels.
2. Removed ternary operation from Message.php, this ternary automatically prefixed channels.
3. Removed one test
4. Added new test